### PR TITLE
Clean Up

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -6,7 +6,6 @@
 
 /// <reference types="tree-sitter-cli/dsl" />
 // @ts-check
-
 module.exports = grammar({
   name: "groq",
 

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -2,11 +2,11 @@
   "grammars": [
     {
       "name": "groq",
-      "camelcase": "Groq",
+      "camelcase": "GROQ",
       "scope": "source.groq",
-      "file-types": [".jsx", ".ts", ".tsx", ".js", ".groq"],
-      "injection-regex": "^groq$",
-      "highlights": ["queries/highlights.scm"]
+      "path": ".",
+      "file-types": ["groq"],
+      "highlights": "queries/highlights.scm"
     }
   ],
   "metadata": {
@@ -33,4 +33,3 @@
     "swift": true
   }
 }
-


### PR DESCRIPTION
This PR cleans up the tree-sitter.json file. This was done in conjunction w/ my `sanity.nvim` plugin to allow for syntax highlighting of groq queries. 